### PR TITLE
Bump text upper version bounds

### DIFF
--- a/usb.cabal
+++ b/usb.cabal
@@ -63,7 +63,7 @@ Library
   build-depends: base                 >= 4     && < 4.8
                , bindings-libusb      >= 1.4.5 && < 1.5
                , bytestring           >= 0.9   && < 0.11
-               , text                 >= 0.5   && < 1.2
+               , text                 >= 0.5   && < 1.3
                , vector               >= 0.5   && < 0.11
 
   exposed-modules: System.USB


### PR DESCRIPTION
Allow `usb` to build with the latest version (1.2.0.0) of `text`.
