### PR TITLE
Set direction bit in control read transfer

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,3 +1,7 @@
+1.3.0.3
+
+	* Fix incorrect direction in controlRead
+
 1.3.0.2
 
 	* Support GHC-7.10.2.

--- a/usb.cabal
+++ b/usb.cabal
@@ -1,5 +1,5 @@
 name:          usb
-version:       1.3.0.2
+version:       1.3.0.3
 cabal-version: >=1.6
 build-type:    Custom
 license:       BSD3


### PR DESCRIPTION
Propagates a TransferDirection through internal control transfer
functions so that when executing a read transfer, the direction bit is
set.

No user-facing APIs were changed.

This resolves issue #13.