### PR TITLE
Upgrade dependencies

### DIFF
--- a/usb.cabal
+++ b/usb.cabal
@@ -60,7 +60,7 @@ source-repository head
 Library
   GHC-Options: -Wall
 
-  build-depends: base                 >= 4     && < 4.9
+  build-depends: base                 >= 4     && < 4.10
                , bindings-libusb      >= 1.4.5 && < 1.5
                , bytestring           >= 0.9   && < 0.11
                , text                 >= 0.5   && < 1.3

--- a/usb.cabal
+++ b/usb.cabal
@@ -85,4 +85,4 @@ Library
 
   if impl(ghc >= 7.2.1)
     cpp-options: -DGENERICS
-    build-depends: ghc-prim >= 0.2 && < 0.5
+    build-depends: ghc-prim >= 0.2 && < 0.6


### PR DESCRIPTION
This pull request upgrades the `base` and `ghc-prim` dependencies to allow their most recent versions. This is necessary to build this package with GHC 8.0.1. 

I was going to upgrade `vector` as well, but I saw that you did that in 7e3ac1551a27b0a75681b30d53d8a20f84672946. Unfortunately version 1.3.0.4 isn't available on Hackage. 